### PR TITLE
fix/ensure valid animal_id is assigned in ClientSeeder

### DIFF
--- a/database/seeders/ClientSeeder.php
+++ b/database/seeders/ClientSeeder.php
@@ -4,8 +4,8 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\Client;
-use Faker\Factory as Faker;
 use App\Models\Animal;
+use Faker\Factory as Faker;
 
 class ClientSeeder extends Seeder
 {
@@ -31,51 +31,54 @@ class ClientSeeder extends Seeder
                 'postal_code' => $faker->postcode,
                 'number_pets' => $faker->numberBetween(1, 5),
                 'observations' => $faker->sentence,
+                'animal_id' => Animal::inRandomOrder()->first()->id,
             ]);
         }
-        Client::create([
-            'name' => 'John',
-            'last_name' => 'Doe',
-            'animal_id' => Animal::inRandomOrder()->first()->id,
-            'phone' => '5551234567',
-            'email' => 'johndoe@example.com',
-            'state' => 'California',
-            'city' => 'Los Angeles',
-            'colony' => 'Downtown',
-            'address' => '1234 Main St',
-            'postal_code' => '90001',
-            'number_pets' => 2,
-            'observations' => 'Regular customer',
-        ]);
 
-        Client::create([
-            'name' => 'Jane',
-            'last_name' => 'Smith',
-            'animal_id' => Animal::inRandomOrder()->first()->id,
-            'phone' => '5557654321',
-            'email' => 'janesmith@example.com',
-            'state' => 'Texas',
-            'city' => 'Houston',
-            'colony' => 'River Oaks',
-            'address' => '5678 Elm St',
-            'postal_code' => '77001',
-            'number_pets' => 3,
-            'observations' => 'VIP customer',
-        ]);
-
-        Client::create([
-            'name' => 'Emily',
-            'last_name' => 'Johnson',
-            'animal_id' => Animal::inRandomOrder()->first()->id,
-            'phone' => '5559876543',
-            'email' => 'emilyjohnson@example.com',
-            'state' => 'Florida',
-            'city' => 'Miami',
-            'colony' => 'Coconut Grove',
-            'address' => '9101 Ocean Dr',
-            'postal_code' => '33101',
-            'number_pets' => 1,
-            'observations' => 'New customer',
-        ]);
+        foreach ([
+            [
+                'name' => 'John',
+                'last_name' => 'Doe',
+                'phone' => '5551234567',
+                'email' => 'johndoe@example.com',
+                'state' => 'California',
+                'city' => 'Los Angeles',
+                'colony' => 'Downtown',
+                'address' => '1234 Main St',
+                'postal_code' => '90001',
+                'number_pets' => 2,
+                'observations' => 'Regular customer',
+            ],
+            [
+                'name' => 'Jane',
+                'last_name' => 'Smith',
+                'phone' => '5557654321',
+                'email' => 'janesmith@example.com',
+                'state' => 'Texas',
+                'city' => 'Houston',
+                'colony' => 'River Oaks',
+                'address' => '5678 Elm St',
+                'postal_code' => '77001',
+                'number_pets' => 3,
+                'observations' => 'VIP customer',
+            ],
+            [
+                'name' => 'Emily',
+                'last_name' => 'Johnson',
+                'phone' => '5559876543',
+                'email' => 'emilyjohnson@example.com',
+                'state' => 'Florida',
+                'city' => 'Miami',
+                'colony' => 'Coconut Grove',
+                'address' => '9101 Ocean Dr',
+                'postal_code' => '33101',
+                'number_pets' => 1,
+                'observations' => 'New customer',
+            ],
+        ] as $data) {
+            Client::create(array_merge($data, [
+                'animal_id' => Animal::inRandomOrder()->first()->id,
+            ]));
+        }
     }
 }


### PR DESCRIPTION
This PR fixes an issue in the `ClientSeeder` where the `animal_id` field was missing, causing SQL errors. The following updates were made:

- **Seeder Update:** The `ClientSeeder` now assigns a random `animal_id` to every client using existing records in the `animals` table.
- **Improved Logic:** Removed unnecessary validations, assuming the `animals` table is already populated.
- **Reliability:** Ensures that all seeded clients are linked to a valid `animal_id`.

## Changes

- Updated `ClientSeeder` to use `Animal::inRandomOrder()->first()->id` for assigning `animal_id`.